### PR TITLE
Fix Z Scaling and Ordering Table size

### DIFF
--- a/src/08_spinningCube/gpu.h
+++ b/src/08_spinningCube/gpu.h
@@ -19,9 +19,11 @@
 #include <stdint.h>
 #include "ps1/gpucmd.h"
 
+// Ordering table size must be a multiple of 24
+#define ORDERING_TABLE_SIZE 48
 #define DMA_MAX_CHUNK_SIZE  16
 #define CHAIN_BUFFER_SIZE   1024
-#define ORDERING_TABLE_SIZE 32
+
 
 typedef struct {
 	uint32_t data[CHAIN_BUFFER_SIZE];

--- a/src/08_spinningCube/main.c
+++ b/src/08_spinningCube/main.c
@@ -63,7 +63,7 @@ static void setupGTE(int width, int height) {
 	// will sum the transformed Z coordinates of its vertices multiplied by this
 	// value in order to derive the ordering table bucket index the polygon will
 	// be sorted into.
-	gte_setZScaleFactor(ONE / ORDERING_TABLE_SIZE);
+	gte_setZScaleFactor((ONE * ORDERING_TABLE_SIZE) / 0x7fff);
 }
 
 // When transforming vertices, the GTE will multiply their vectors by a 3x3

--- a/src/ps1/cop0gte.h
+++ b/src/ps1/cop0gte.h
@@ -167,7 +167,7 @@ typedef enum {
 typedef struct {
 	int16_t x, y, z;
 	uint8_t _padding[2];
-} GTEVector16;
+} __attribute((aligned(4))) GTEVector16;
 
 typedef struct {
 	int32_t x, y, z;


### PR DESCRIPTION
These are the two main fixes we made.
I did add a comment to the Ordering Table size macro.
Given that it's your tutorial, you may want to add comments to explain exactly why we do this as, frankly, I'm not 100% sure why it works!
Just keep in mind that the ordering table size should be a multiple of 24
