### PR TITLE
Added A/B comparison as polling IRQ_STAT is glitchy.

### DIFF
--- a/src/09_controllers/main.c
+++ b/src/09_controllers/main.c
@@ -88,8 +88,19 @@ static bool waitForAcknowledge(int timeout) {
 	// interface to the interrupt controller. This is not guaranteed to happen
 	// (it will not if e.g. no device is connected), so we have to implement a
 	// timeout to avoid waiting forever in such cases.
-	for (; timeout > 0; timeout -= 10) {
-		if (IRQ_STAT & (1 << IRQ_SIO0)) {
+
+	timeout -= 10;
+	delayMicroseconds(10);	// An ACK should happen around about 10-20 microseconds later
+	
+	int adjustedTimeout = timeout / 20;
+	for (; adjustedTimeout < timeout; adjustedTimeout += 20);
+
+	for (; adjustedTimeout > 0; adjustedTimeout -= 20) {
+		uint16_t a = IRQ_STAT;
+		delayMicroseconds(10); // Reading IRQ_STAT too fast can cause glitching and false positives.
+		uint16_t b = IRQ_STAT;
+
+		if (a == b && a & (1 << IRQ_SIO0)) {	// A/B comparison all but eliminates false positives.
 			// Reset the interrupt controller and serial interface's flags to
 			// ensure the interrupt can be triggered again.
 			IRQ_STAT     = ~(1 << IRQ_SIO0);
@@ -152,12 +163,12 @@ static uint8_t exchangeByte(uint8_t value) {
 	// Wait until the interface is ready to accept a byte to send, then wait for
 	// it to finish receiving the byte sent by the device.
 	while (!(SIO_STAT(0) & SIO_STAT_TX_NOT_FULL))
-		__asm__ volatile("");
+		delayMicroseconds(5);
 
 	SIO_DATA(0) = value;
 
 	while (!(SIO_STAT(0) & SIO_STAT_RX_NOT_EMPTY))
-		__asm__ volatile("");
+		delayMicroseconds(5);
 
 	return SIO_DATA(0);
 }


### PR DESCRIPTION
Added A/B comparison as polling IRQ_STAT is glitchy especially when done fast. Also slowed loop down as even that could cause false positives on slower controllers.

On real hardware, genuine Sony digital controllers would 'respond' with 5 bytes instead of 4. This was due to a false positive caused from a glitch in IRQ_STAT.

Also slowed the loop by half (adjusts the input timeout value accordingly) to also prevent slow controllers from causing a glitch to occur.

Finally, added 5 microsecond delays into exchangeByte more out of precaution incase similar gitching occured.

These changes make Sony controller reading rock solid and slow controllers actually work.